### PR TITLE
Feature/#1-menu-search

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,8 @@ repositories {
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation group: 'com.squareup.okhttp', name: 'okhttp', version: '2.7.5'
+	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/podong/icanread/app/dto/MenuDto.java
+++ b/src/main/java/com/podong/icanread/app/dto/MenuDto.java
@@ -1,0 +1,19 @@
+package com.podong.icanread.app.dto;
+
+import com.podong.icanread.domain.menu.Menu;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class MenuDto {
+    private String name;
+    private String meaning;
+    private String image;
+
+    public MenuDto(Menu entity){
+        this.name = entity.getName();
+        this.meaning = entity.getMeaning();
+        this.image = entity.getImage();
+    }
+}

--- a/src/main/java/com/podong/icanread/app/wikipedia/WikipediaClient.java
+++ b/src/main/java/com/podong/icanread/app/wikipedia/WikipediaClient.java
@@ -1,0 +1,58 @@
+package com.podong.icanread.app.wikipedia;
+
+import com.squareup.okhttp.OkHttpClient;
+import com.squareup.okhttp.Request;
+import com.squareup.okhttp.Response;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+
+import java.io.IOException;
+@Slf4j
+public class WikipediaClient {
+    final String BASE_URL = "https://ko.wikipedia.org/api/rest_v1/page/summary/";
+    String menuName;
+    String displayTitle = "";
+    String imageURL = "";
+    String meaning = "";
+
+    public WikipediaClient(String menuName){
+        this.menuName = menuName;
+        getMeaningAndImage();
+    }
+    private void getMeaningAndImage(){
+        OkHttpClient client = new OkHttpClient();
+        Request request = new Request.Builder()
+                .url(BASE_URL+menuName)
+                .get()
+                .build();
+        try{
+            Response response = client.newCall(request).execute();
+            String data = response.body().string();
+            JSONParser parser = new JSONParser();
+            JSONObject jsonObject = (JSONObject) parser.parse(data);
+
+            // 제목 가져오기
+            displayTitle = (String) jsonObject.get("displaytitle");
+
+            // 이미지 URL 가져오기
+            JSONObject jsonObjectOriginalImage = (JSONObject) jsonObject.get("originalimage");
+            imageURL = (String) jsonObjectOriginalImage.get("source");
+
+            // 동음이의어일 경우엔 어떻게 가져올지 이야기해보기
+
+            // 뜻 가져오기
+            meaning = (String) jsonObject.get("extract");
+
+        } catch (IOException | ParseException e) {
+            e.printStackTrace();
+        }
+    }
+    public String getImageURL(){
+        return imageURL;
+    }
+    public String getMeaning(){
+        return meaning;
+    }
+}

--- a/src/main/java/com/podong/icanread/controller/MenuController.java
+++ b/src/main/java/com/podong/icanread/controller/MenuController.java
@@ -1,0 +1,22 @@
+package com.podong.icanread.controller;
+
+import com.podong.icanread.app.dto.MenuDto;
+import com.podong.icanread.service.menu.MenuService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RequiredArgsConstructor
+@RestController
+@Slf4j
+public class MenuController {
+    private final MenuService menuService;
+
+    // 메뉴 이름으로 메뉴 조회 테스트용 API
+    @GetMapping("/api/v1/menu")
+    public MenuDto findByName(@RequestParam("name") String name){
+        return menuService.findByName(name);
+    }
+}

--- a/src/main/java/com/podong/icanread/domain/menu/Menu.java
+++ b/src/main/java/com/podong/icanread/domain/menu/Menu.java
@@ -1,0 +1,39 @@
+package com.podong.icanread.domain.menu;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.DynamicInsert;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@NoArgsConstructor
+@DynamicInsert
+@Table(name="MENU")
+public class Menu {
+    // Menu 테이블 기본키(PK)
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 테이블 칼럼 - 메뉴 이름
+    @Column(length = 50, nullable = false)
+    private String name;
+
+    // 테이블 칼럼 - 메뉴 뜻풀이
+    @Column(nullable = false)
+    private String meaning;
+
+    // 테이블 칼럼 - 메뉴 이미지 URL
+    @Column(nullable = false)
+    private String image;
+
+    @Builder
+    public Menu(String name, String meaning, String image){
+        this.name = name;
+        this.meaning = meaning;
+        this.image = image;
+    }
+}

--- a/src/main/java/com/podong/icanread/domain/menu/MenuRepository.java
+++ b/src/main/java/com/podong/icanread/domain/menu/MenuRepository.java
@@ -1,0 +1,13 @@
+package com.podong.icanread.domain.menu;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.Optional;
+
+public interface MenuRepository extends JpaRepository<Menu, Long> {
+    // 메뉴 이름으로 DB에 있는지 조회
+    @Query("SELECT m FROM Menu m WHERE name = :name")
+    Optional<Menu> findByName(@Param("name") String name);
+}

--- a/src/main/java/com/podong/icanread/service/menu/MenuService.java
+++ b/src/main/java/com/podong/icanread/service/menu/MenuService.java
@@ -1,0 +1,21 @@
+package com.podong.icanread.service.menu;
+
+import com.podong.icanread.app.dto.MenuDto;
+import com.podong.icanread.domain.menu.Menu;
+import com.podong.icanread.domain.menu.MenuRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class MenuService {
+    private final MenuRepository menuRepository;
+
+    public MenuDto findByName(String name) {
+        Menu entity = menuRepository.findByName(name)
+                .orElseThrow(() -> new IllegalArgumentException("해당 메뉴가 없습니다. 메뉴명 :" + name));
+        return new MenuDto(entity);
+    }
+}

--- a/src/main/java/com/podong/icanread/service/menu/MenuService.java
+++ b/src/main/java/com/podong/icanread/service/menu/MenuService.java
@@ -1,11 +1,14 @@
 package com.podong.icanread.service.menu;
 
 import com.podong.icanread.app.dto.MenuDto;
+import com.podong.icanread.app.wikipedia.WikipediaClient;
 import com.podong.icanread.domain.menu.Menu;
 import com.podong.icanread.domain.menu.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
@@ -14,8 +17,23 @@ public class MenuService {
     private final MenuRepository menuRepository;
 
     public MenuDto findByName(String name) {
-        Menu entity = menuRepository.findByName(name)
-                .orElseThrow(() -> new IllegalArgumentException("해당 메뉴가 없습니다. 메뉴명 :" + name));
+        Optional<Menu> entity = menuRepository.findByName(name);
+        if (entity.isPresent()){ // 메뉴가 DB에 존재하는 경우
+            return new MenuDto(entity.get());
+        }
+        else{ // 메뉴가 DB에 존재하지 않는 경우
+            return searchByWikipedia(name);
+        }
+    }
+
+    // 위키피디아에서 메뉴 뜻, 이미지 가져오는 메소드
+    public MenuDto searchByWikipedia(String name){
+        WikipediaClient wikipediaClient = new WikipediaClient(name);
+        Menu entity = Menu.builder()
+                .name(name)
+                .meaning(wikipediaClient.getMeaning())
+                .image(wikipediaClient.getImageURL())
+                .build();
         return new MenuDto(entity);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,19 @@
+# query log check
+spring.jpa.show_sql=true
 
+# change h2 grammar to mysql
+spring.jpa.properties.hibernate.dialect=org.hibernate.dialect.MySQL57InnoDBDialect
+spring.jpa.properties.hibernate.dialect.storage_engine=innodb
+spring.datasource.hikari.jdbc-url=jdbc:h2:mem:testdb;MODE=MYSQL;DB_CLOSE_ON_EXIT=FALSE
+spring.datasource.hikari.username=sa
+
+spring.h2.console.enabled=true
+spring.profiles.include=oauth
+spring.session.store-type=jdbc
+
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.generate-ddl=true
+
+# log
+logging.level.root=info
+logging.level.groupId.artifactId=debug;

--- a/src/test/java/com/podong/icanread/service/menu/MenuServiceTest.java
+++ b/src/test/java/com/podong/icanread/service/menu/MenuServiceTest.java
@@ -1,5 +1,6 @@
 package com.podong.icanread.service.menu;
 
+import com.podong.icanread.app.wikipedia.WikipediaClient;
 import com.podong.icanread.domain.menu.Menu;
 import com.podong.icanread.domain.menu.MenuRepository;
 import org.junit.jupiter.api.AfterEach;
@@ -9,6 +10,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.Optional;
 
@@ -23,6 +25,9 @@ public class MenuServiceTest {
     MenuRepository menuRepository;
 
     MenuService menuService;
+
+    @Autowired
+    WikipediaClient wikipediaClient;
 
     @BeforeEach
     void setup() {
@@ -49,5 +54,13 @@ public class MenuServiceTest {
 
         // 해당 Mock 이 더 이상 interactional 발생되지 않아야 한다.
         verifyNoMoreInteractions(menuRepository);
+    }
+
+    @Test
+    @DisplayName("위키피디아에서 메뉴 뜻과 이미지 잘 받아오는지 확인")
+    public void wikipediaTest() {
+        wikipediaClient = new WikipediaClient("카페라떼");
+        System.out.println(wikipediaClient.getMeaning());
+        System.out.println(wikipediaClient.getImageURL());
     }
 }

--- a/src/test/java/com/podong/icanread/service/menu/MenuServiceTest.java
+++ b/src/test/java/com/podong/icanread/service/menu/MenuServiceTest.java
@@ -1,0 +1,53 @@
+package com.podong.icanread.service.menu;
+
+import com.podong.icanread.domain.menu.Menu;
+import com.podong.icanread.domain.menu.MenuRepository;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+@ExtendWith(MockitoExtension.class)
+public class MenuServiceTest {
+    @Mock
+    MenuRepository menuRepository;
+
+    MenuService menuService;
+
+    @BeforeEach
+    void setup() {
+        this.menuService = new MenuService(menuRepository);
+    }
+
+    @AfterEach
+    public void cleanup() {menuRepository.deleteAll();}
+
+    @Test
+    @DisplayName("메뉴 이름으로 DB에서 메뉴 조회 가능한지 체크")
+    void mock_test() {
+        Optional<Menu> menu = Optional.of(Menu.builder().name("아메리카노").meaning("에스프레소에 뜨거운 물을 더한 커피").image("https://kfcapi.inicis.com/kfcs_api_img/KFCS/goods/DL_1444725_20220704182019850.png").build());
+
+        when(menuRepository.findByName(anyString())).thenReturn(menu);
+
+        assertEquals(menuService.findByName("아메리카노").getName(), "아메리카노");
+
+        // 목 객체의 findByName 한 번 실행되었는지 검증
+        verify(menuRepository, times(1)).findByName("아메리카노");
+
+        // findAll이 한번도 실행하지 않았는지 검증
+        verify(menuRepository, never()).findAll();
+
+        // 해당 Mock 이 더 이상 interactional 발생되지 않아야 한다.
+        verifyNoMoreInteractions(menuRepository);
+    }
+}


### PR DESCRIPTION
## 📌 관련 이슈
resolve #1

## 📝 개요
메뉴 뜻, 이미지 검색

## ✨ 작업 사항
- 메뉴 Entity, Repository, DTO 생성
- 메뉴 이름으로 DB에서 메뉴 조회
- DB에 존재하지 않는 메뉴들은 Wikipedia API를 통해 뜻, 이미지 가져오기

## 📚 참고 사항
- 동음이의어일 경우 Wikipedia에서 이미지, 뜻을 가져오지 못하는 이슈가 발생할 수 있음