### PR TITLE
Feature/#7-naver-search-api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+src/main/resources/application.properties

--- a/src/main/java/com/podong/icanread/app/naver/NaverClient.java
+++ b/src/main/java/com/podong/icanread/app/naver/NaverClient.java
@@ -1,0 +1,70 @@
+package com.podong.icanread.app.naver;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
+import org.json.simple.parser.ParseException;
+import org.springframework.http.RequestEntity;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.nio.charset.StandardCharsets;
+
+@Slf4j
+@RequiredArgsConstructor
+public class NaverClient {
+    final String BASE_URL = "https://openapi.naver.com/v1/search/encyc.json";
+
+    String menuName;
+    String meaning;
+    String imageURL;
+    private String clientId;
+    private String clientSecret;
+
+    public NaverClient(String menuName, String clientId, String clientSecret) throws ParseException {
+        this.menuName = menuName;
+        this.clientId = clientId;
+        this.clientSecret = clientSecret;
+        naverSearchEncyclopediaResult();
+    }
+
+    public void naverSearchEncyclopediaResult() throws ParseException {
+        URI uri = UriComponentsBuilder
+                .fromUriString("https://openapi.naver.com")
+                .path("/v1/search/encyc.json")
+                .queryParam("query", menuName)
+                .queryParam("display", 10)
+                .queryParam("start", 1)
+                .encode(StandardCharsets.UTF_8)
+                .build()
+                .toUri();
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        // Header를 사용
+        RequestEntity<Void> req = RequestEntity
+                .get(uri)
+                .header("X-Naver-Client-Id", clientId)
+                .header("X-Naver-Client-Secret", clientSecret)
+                .build();
+
+        ResponseEntity<String> searchResult = restTemplate.exchange(req, String.class);
+        String data = searchResult.getBody();
+        JSONParser parser = new JSONParser();
+        JSONObject jsonObject = (JSONObject) parser.parse(data);
+        JSONArray parseItems = (JSONArray) jsonObject.get("items");
+        JSONObject firstItem = (JSONObject) parseItems.get(0);
+        meaning = firstItem.get("description").toString();
+        imageURL = firstItem.get("thumbnail").toString();
+    }
+    public String getImageURL(){
+        return imageURL;
+    }
+    public String getMeaning(){
+        return meaning;
+    }
+}

--- a/src/main/java/com/podong/icanread/app/naver/NaverClient.java
+++ b/src/main/java/com/podong/icanread/app/naver/NaverClient.java
@@ -59,6 +59,11 @@ public class NaverClient {
         JSONArray parseItems = (JSONArray) jsonObject.get("items");
         JSONObject firstItem = (JSONObject) parseItems.get(0);
         meaning = firstItem.get("description").toString();
+
+        if (meaning.contains("<")){ // 태그 존재할 경우 태그 제외
+            meaning = meaning.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", "");
+        }
+        
         imageURL = firstItem.get("thumbnail").toString();
     }
     public String getImageURL(){

--- a/src/main/java/com/podong/icanread/app/wikipedia/WikipediaClient.java
+++ b/src/main/java/com/podong/icanread/app/wikipedia/WikipediaClient.java
@@ -16,6 +16,7 @@ public class WikipediaClient {
     String displayTitle = "";
     String imageURL;
     String meaning;
+    boolean checkDataNull = false;
 
     public WikipediaClient(String menuName){
         this.menuName = menuName;
@@ -43,15 +44,14 @@ public class WikipediaClient {
                 // 뜻 가져오기
                 meaning = (String) jsonObject.get("extract");
             } catch (NullPointerException e){
-                changeNullToEmptyString(imageURL, meaning);
+                checkDataNull = true;
             }
         } catch (IOException | ParseException e) {
             e.printStackTrace();
         }
     }
-    private void changeNullToEmptyString(String imageURL, String meaning){
-        this.imageURL = imageURL == null ? "" : imageURL;
-        this.meaning = meaning == null ? "" : meaning;
+    public boolean isCheckDataNull(){
+        return checkDataNull;
     }
     public String getImageURL(){
         return imageURL;

--- a/src/main/java/com/podong/icanread/controller/MenuController.java
+++ b/src/main/java/com/podong/icanread/controller/MenuController.java
@@ -4,6 +4,7 @@ import com.podong.icanread.app.dto.MenuDto;
 import com.podong.icanread.service.menu.MenuService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.json.simple.parser.ParseException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -18,5 +19,11 @@ public class MenuController {
     @GetMapping("/api/v1/menu")
     public MenuDto findByName(@RequestParam("name") String name){
         return menuService.findByName(name);
+    }
+
+    // Naver Search API 결과 테스트
+    @GetMapping("/api/v1/naver")
+    public MenuDto naverSearch(@RequestParam("name") String name) throws ParseException {
+        return menuService.searchByNaver(name);
     }
 }

--- a/src/main/java/com/podong/icanread/controller/MenuController.java
+++ b/src/main/java/com/podong/icanread/controller/MenuController.java
@@ -17,7 +17,7 @@ public class MenuController {
 
     // 메뉴 이름으로 메뉴 조회 테스트용 API
     @GetMapping("/api/v1/menu")
-    public MenuDto findByName(@RequestParam("name") String name){
+    public MenuDto findByName(@RequestParam("name") String name) throws ParseException {
         return menuService.findByName(name);
     }
 

--- a/src/main/java/com/podong/icanread/service/menu/MenuService.java
+++ b/src/main/java/com/podong/icanread/service/menu/MenuService.java
@@ -1,20 +1,28 @@
 package com.podong.icanread.service.menu;
 
 import com.podong.icanread.app.dto.MenuDto;
+import com.podong.icanread.app.naver.NaverClient;
 import com.podong.icanread.app.wikipedia.WikipediaClient;
 import com.podong.icanread.domain.menu.Menu;
 import com.podong.icanread.domain.menu.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.json.simple.parser.ParseException;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
 
 @Slf4j
-@RequiredArgsConstructor
 @Service
+@RequiredArgsConstructor
 public class MenuService {
     private final MenuRepository menuRepository;
+    @Value("${naver.id}")
+    private String naverClientId;
+
+    @Value("${naver.secret}")
+    private String naverClientSecret;
 
     public MenuDto findByName(String name) {
         Optional<Menu> entity = menuRepository.findByName(name);
@@ -33,6 +41,18 @@ public class MenuService {
                 .name(name)
                 .meaning(wikipediaClient.getMeaning())
                 .image(wikipediaClient.getImageURL())
+                .build();
+        menuRepository.save(entity);
+        return new MenuDto(entity);
+    }
+
+    // 네이버에서 받아온 메뉴 뜻, 이미지 DB에 저장하고 리턴하는 메소드
+    public MenuDto searchByNaver(String name) throws ParseException {
+        NaverClient naverClient = new NaverClient(name, naverClientId, naverClientSecret);
+        Menu entity = Menu.builder()
+                .name(name)
+                .meaning(naverClient.getMeaning())
+                .image(naverClient.getImageURL())
                 .build();
         menuRepository.save(entity);
         return new MenuDto(entity);

--- a/src/test/java/com/podong/icanread/app/naver/NaverClientTest.java
+++ b/src/test/java/com/podong/icanread/app/naver/NaverClientTest.java
@@ -1,0 +1,28 @@
+package com.podong.icanread.app.naver;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.DisplayName;
+
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public class NaverClientTest {
+    @Test
+    @DisplayName("네이버 백과사전 검색 API에서 받아오는 데이터 필터링 테스트")
+    public void testMeaningFiltering_fromNaverSearchApi(){
+        String meaning = "적당량의 뜨거운 물을 섞는 방식이 연한 커피를 즐기는 미국에서 시작된 것이라 하여 ‘<b>아메리카노</b>’라 부른다. 우리나라에서도 가장 인기 있는 메뉴 중 하나이다. 에스프레소에 쓰이는 원두와 물의 양에 따라... ";
+        // 태그 제외
+        meaning = meaning.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", "");
+        System.out.println(getTwoSentences(meaning));
+    }
+
+    // 2문장까지만 가져오기
+    private String getTwoSentences (String str) {
+        Pattern pattern = Pattern.compile("(.*?)[.](.*?)[.]");
+        Matcher matcher = pattern.matcher(str);
+        if(matcher.find()){
+            return str.substring(0, matcher.end());
+        }
+        return null;
+    }
+}

--- a/src/test/java/com/podong/icanread/service/menu/MenuServiceTest.java
+++ b/src/test/java/com/podong/icanread/service/menu/MenuServiceTest.java
@@ -3,6 +3,7 @@ package com.podong.icanread.service.menu;
 import com.podong.icanread.app.wikipedia.WikipediaClient;
 import com.podong.icanread.domain.menu.Menu;
 import com.podong.icanread.domain.menu.MenuRepository;
+import org.json.simple.parser.ParseException;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
@@ -39,7 +40,7 @@ public class MenuServiceTest {
 
     @Test
     @DisplayName("메뉴 이름으로 DB에서 메뉴 조회 가능한지 체크")
-    void mock_test() {
+    void mock_test() throws ParseException {
         Optional<Menu> menu = Optional.of(Menu.builder().name("아메리카노").meaning("에스프레소에 뜨거운 물을 더한 커피").image("https://kfcapi.inicis.com/kfcs_api_img/KFCS/goods/DL_1444725_20220704182019850.png").build());
 
         when(menuRepository.findByName(anyString())).thenReturn(menu);


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 관련있는 이슈 번호(#000)을 적어주세요 -->
resolve #7

## 📝 개요
네이버 백과사전 검색 API 추가

## ✨ 작업 사항
- 네이버 백과사전 검색 API 연동
- 네이버 백과사전 검색 API를 통해 받아온 데이터에 `<b></b>` 같은 태그들 모두 제거 (정규식 사용)
- 위키피디아 API 에서 받아오지 못한 경우, 네이버 백과사전 검색 API를 이용하여 메뉴 뜻을 가져올 수 있도록 메뉴 서비스 로직 업데이트
- 네이버 백과사전 검색 API에서 데이터 받아오지 못한 경우, 예외 처리

## 📚 참고 사항
검색 결과가 있긴 한데, 뜻풀이가 아닌 생뚱맞은 정보가 들어오는 이슈가 발생할 수 있음 
- ex) 바닐라라떼