### PR TITLE
Feature/#10-menu-list-api

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,6 +23,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation group: 'com.squareup.okhttp', name: 'okhttp', version: '2.7.5'
 	implementation group: 'com.googlecode.json-simple', name: 'json-simple', version: '1.1.1'
+	implementation 'org.springframework.boot:spring-boot-starter-webflux'
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/src/main/java/com/podong/icanread/app/dto/MlResponseDto.java
+++ b/src/main/java/com/podong/icanread/app/dto/MlResponseDto.java
@@ -1,0 +1,16 @@
+package com.podong.icanread.app.dto;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.ArrayList;
+
+@Getter
+@NoArgsConstructor
+public class MlResponseDto {
+    ArrayList<String> textList;
+
+    public void setTextList(ArrayList<String> textList) {
+        this.textList = textList;
+    }
+}

--- a/src/main/java/com/podong/icanread/app/exception/ErrorCode.java
+++ b/src/main/java/com/podong/icanread/app/exception/ErrorCode.java
@@ -15,6 +15,8 @@ public enum ErrorCode {
     /* 401 UNAUTHORIZED : 인증되지 않은 사용자 */
 
     /* 404 NOT_FOUND : Resource 를 찾을 수 없음 */
+    NOT_FOUND_TEXT_LIST(NOT_FOUND, "ML에서 추출한 메뉴 리스트를 받아오지 못했습니다."),
+    NOT_FOUND_FILE(NOT_FOUND, "파일을 찾을 수 없습니다."),
 
     /* 409 CONFLICT : Resource 의 현재 상태와 충돌. 보통 중복된 데이터 존재 */
     DUPLICATE_RESOURCE(CONFLICT, "데이터가 이미 존재합니다"),

--- a/src/main/java/com/podong/icanread/app/ml/MlClient.java
+++ b/src/main/java/com/podong/icanread/app/ml/MlClient.java
@@ -1,0 +1,76 @@
+package com.podong.icanread.app.ml;
+
+import com.podong.icanread.app.dto.MlResponseDto;
+import com.podong.icanread.app.exception.CustomException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.core.io.InputStreamResource;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
+import org.springframework.web.reactive.function.BodyInserters;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
+import java.util.ArrayList;
+
+import static com.podong.icanread.app.exception.ErrorCode.NOT_FOUND_TEXT_LIST;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class MlClient {
+    // ML 서버에 이미지 보내고, Text List 받아오기
+    public MlResponseDto receiveTextListFromMl(@RequestParam("file") MultipartFile file) throws IOException{
+        WebClient client = WebClient.create("http://localhost:8080"); // ML 서버 주소로 나중에 수정하기
+        MultiValueMap<String, Object> formData = new LinkedMultiValueMap<>();
+        formData.add("file", new MultipartInputStreamFileResource(file.getInputStream(), file.getOriginalFilename()));
+        return client.post()
+                .uri("/menu/extract")
+                .contentType(MediaType.MULTIPART_FORM_DATA)
+                .body(BodyInserters.fromMultipartData(formData))
+                .retrieve()
+                .bodyToMono(MlResponseDto.class)
+                .timeout(Duration.ofMillis(1000))
+                .blockOptional().orElseThrow(
+                        () -> new CustomException(NOT_FOUND_TEXT_LIST)
+                );
+    }
+
+    // ML 서버 역할
+    public MlResponseDto mlServer(@RequestParam("file") MultipartFile file) {
+        ArrayList<String> textList = new ArrayList<>();
+        textList.add("아메리카노");
+        textList.add("카페모카");
+        textList.add("카푸치노");
+        MlResponseDto mlResponseDto = new MlResponseDto();
+        mlResponseDto.setTextList(textList);
+        return mlResponseDto;
+    }
+
+    // MultipartFile 자체 대신 MultipartMap에 MultipartFile의 바이트를 추가하기 위한 클래스
+    static class MultipartInputStreamFileResource extends InputStreamResource {
+
+        private final String filename;
+
+        MultipartInputStreamFileResource(InputStream inputStream, String filename) {
+            super(inputStream);
+            this.filename = filename;
+        }
+
+        @Override
+        public String getFilename() {
+            return this.filename;
+        }
+
+        @Override
+        public long contentLength() throws IOException {
+            return -1; // we do not want to generally read the whole stream into memory ...
+        }
+    }
+}

--- a/src/main/java/com/podong/icanread/app/naver/NaverClient.java
+++ b/src/main/java/com/podong/icanread/app/naver/NaverClient.java
@@ -64,6 +64,9 @@ public class NaverClient {
                 if (meaning.contains("<")){ // 태그 존재할 경우 태그 제외
                     meaning = meaning.replaceAll("<(/)?([a-zA-Z]*)(\\s[a-zA-Z]*=[^>]*)?(\\s)*(/)?>", "");
                 }
+                if (meaning.contains("[영양성분]")){ // 영양성분일 경우 빈스트링으로 처리
+                    meaning = "";
+                }
                 imageURL = firstItem.get("thumbnail").toString();
             } catch (IndexOutOfBoundsException | NullPointerException e){
                 changeNullToEmptyString(meaning, imageURL);

--- a/src/main/java/com/podong/icanread/app/wikipedia/WikipediaClient.java
+++ b/src/main/java/com/podong/icanread/app/wikipedia/WikipediaClient.java
@@ -43,6 +43,9 @@ public class WikipediaClient {
 
                 // 뜻 가져오기
                 meaning = (String) jsonObject.get("extract");
+                if (meaning.length() >= 255){
+                    meaning = meaning.substring(0, 250)+"...";
+                }
             } catch (NullPointerException e){
                 checkDataNull = true;
             }

--- a/src/main/java/com/podong/icanread/controller/MenuController.java
+++ b/src/main/java/com/podong/icanread/controller/MenuController.java
@@ -1,23 +1,30 @@
 package com.podong.icanread.controller;
 
+import com.podong.icanread.app.dto.MlResponseDto;
 import com.podong.icanread.app.dto.MenuDto;
+import com.podong.icanread.app.exception.CustomException;
+import com.podong.icanread.app.ml.MlClient;
 import com.podong.icanread.service.menu.MenuService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.simple.parser.ParseException;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.multipart.MultipartFile;
 
+import java.io.IOException;
+import java.util.ArrayList;
 import java.util.List;
+
+import static com.podong.icanread.app.exception.ErrorCode.NOT_FOUND_FILE;
 
 @RequiredArgsConstructor
 @RestController
 @Slf4j
 public class MenuController {
     private final MenuService menuService;
+    private final MlClient mlClient;
 
     // 메뉴 이름으로 메뉴 조회 테스트용 API
     @GetMapping("/api/v1/menu")
@@ -31,9 +38,31 @@ public class MenuController {
         return menuService.searchByNaver(name);
     }
 
-    // 이미지 request body로 뒀을 때, 재구성된 메뉴 리스트 조회 테스트 API (FE <-> BE OK)
+    // 재구성된 메뉴 리스트 조회 테스트 API (FE <-> BE <-> ML)
     @PostMapping("/api/v1/menu/list")
-    public List<MenuDto> reorganizedMenuList(@RequestParam("file") MultipartFile file) {
-        return menuService.extractedTextListFromML();
+    public List<MenuDto> reorganizedMenuList(@RequestParam("file") MultipartFile file) throws IOException {
+        if (!file.isEmpty()){
+            return menuService.extractedTextListFromML(file);
+        }
+        else{
+            throw new CustomException(NOT_FOUND_FILE);
+        }
+    }
+
+    // 이미지 request body로 뒀을 때, 재구성된 메뉴 리스트 조회 테스트 API (BE <-> ML OK)
+    @PostMapping("/api/v1/ml/test")
+    public ArrayList<String> textList(@RequestParam("file") MultipartFile file) throws IOException {
+        if (!file.isEmpty()){
+            return mlClient.receiveTextListFromMl(file).getTextList();
+        }
+        else{
+            throw new CustomException(NOT_FOUND_FILE);
+        }
+    }
+
+    // ML 서버에 요청할 API 역할
+    @PostMapping("/menu/extract")
+    public MlResponseDto checkMlServer(@RequestParam("file") MultipartFile file) {
+        return mlClient.mlServer(file);
     }
 }

--- a/src/main/java/com/podong/icanread/controller/MenuController.java
+++ b/src/main/java/com/podong/icanread/controller/MenuController.java
@@ -6,8 +6,12 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.parser.ParseException;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 @RequiredArgsConstructor
 @RestController
@@ -17,13 +21,19 @@ public class MenuController {
 
     // 메뉴 이름으로 메뉴 조회 테스트용 API
     @GetMapping("/api/v1/menu")
-    public MenuDto findByName(@RequestParam("name") String name) throws ParseException {
+    public MenuDto findByName(@RequestParam("name") String name) {
         return menuService.findByName(name);
     }
 
     // Naver Search API 결과 테스트
     @GetMapping("/api/v1/naver")
-    public MenuDto naverSearch(@RequestParam("name") String name) throws ParseException {
+    public MenuDto naverSearch(@RequestParam("name") String name) {
         return menuService.searchByNaver(name);
+    }
+
+    // 이미지 request body로 뒀을 때, 재구성된 메뉴 리스트 조회 테스트 API (FE <-> BE OK)
+    @PostMapping("/api/v1/menu/list")
+    public List<MenuDto> reorganizedMenuList(@RequestParam("file") MultipartFile file) {
+        return menuService.extractedTextListFromML();
     }
 }

--- a/src/main/java/com/podong/icanread/service/menu/MenuService.java
+++ b/src/main/java/com/podong/icanread/service/menu/MenuService.java
@@ -1,17 +1,19 @@
 package com.podong.icanread.service.menu;
 
 import com.podong.icanread.app.dto.MenuDto;
+import com.podong.icanread.app.ml.MlClient;
 import com.podong.icanread.app.naver.NaverClient;
 import com.podong.icanread.app.wikipedia.WikipediaClient;
 import com.podong.icanread.domain.menu.Menu;
 import com.podong.icanread.domain.menu.MenuRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,6 +22,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class MenuService {
     private final MenuRepository menuRepository;
+    private final MlClient mlClient;
     @Value("${naver.id}")
     private String naverClientId;
 
@@ -64,13 +67,9 @@ public class MenuService {
         return new MenuDto(entity);
     }
 
-    // ML에서 텍스트 리스트 받아오는 로직 (수정 예정)
-    public List<MenuDto> extractedTextListFromML() {
-        String[] data = {"에스프레소", "아메리카노", "카페 모카", "카페 라떼", "카푸치노", "캐러멜 마키아토", "민트 초콜릿",
-                "에스프레소", "바닐라 라떼", "차가운 음료", "오렌지 주스", "애플 주스", "아이스 라떼", "아이스 모카", "아이스 티",
-                "디저트", "레드 벨벳 케이크", "마카롱", "크루아상", "치즈 케이크", "애플 파이", "피칸 파이", "초콜릿 케이크",
-                "민트 컵케이크", "샌드위치", "달걀 & 햄", "오몰렛", "햄 & 치즈", "햄버거", "치즈 버거"};
-        return makeMenuList(new ArrayList<>(Arrays.asList(data)));
+    // ML에서 텍스트 리스트 받아오기
+    public List<MenuDto> extractedTextListFromML(MultipartFile file) throws IOException {
+        return makeMenuList(mlClient.receiveTextListFromMl(file).getTextList());
     }
 
     // ML에서 텍스트 리스트 받아오면 뜻풀이, 이미지 추가한 메뉴판 새로 만들기

--- a/src/main/java/com/podong/icanread/service/menu/MenuService.java
+++ b/src/main/java/com/podong/icanread/service/menu/MenuService.java
@@ -10,7 +10,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.simple.parser.ParseException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
-
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 import java.util.Optional;
 
 @Slf4j
@@ -24,7 +26,7 @@ public class MenuService {
     @Value("${naver.secret}")
     private String naverClientSecret;
 
-    public MenuDto findByName(String name) throws ParseException {
+    public MenuDto findByName(String name) {
         Optional<Menu> entity = menuRepository.findByName(name);
         if (entity.isPresent()){ // 메뉴가 DB에 존재하는 경우
             return new MenuDto(entity.get());
@@ -46,7 +48,7 @@ public class MenuService {
     }
 
     // Naver Encyclopedia Search API 연동
-    public MenuDto searchByNaver(String name) throws ParseException {
+    public MenuDto searchByNaver(String name) {
         NaverClient naverClient = new NaverClient(name, naverClientId, naverClientSecret);
         return saveData(name, naverClient.getMeaning(), naverClient.getImageURL());
     }
@@ -60,5 +62,23 @@ public class MenuService {
                 .build();
         menuRepository.save(entity);
         return new MenuDto(entity);
+    }
+
+    // ML에서 텍스트 리스트 받아오는 로직 (수정 예정)
+    public List<MenuDto> extractedTextListFromML() {
+        String[] data = {"에스프레소", "아메리카노", "카페 모카", "카페 라떼", "카푸치노", "캐러멜 마키아토", "민트 초콜릿",
+                "에스프레소", "바닐라 라떼", "차가운 음료", "오렌지 주스", "애플 주스", "아이스 라떼", "아이스 모카", "아이스 티",
+                "디저트", "레드 벨벳 케이크", "마카롱", "크루아상", "치즈 케이크", "애플 파이", "피칸 파이", "초콜릿 케이크",
+                "민트 컵케이크", "샌드위치", "달걀 & 햄", "오몰렛", "햄 & 치즈", "햄버거", "치즈 버거"};
+        return makeMenuList(new ArrayList<>(Arrays.asList(data)));
+    }
+
+    // ML에서 텍스트 리스트 받아오면 뜻풀이, 이미지 추가한 메뉴판 새로 만들기
+    public List<MenuDto> makeMenuList(ArrayList<String> data) {
+        ArrayList<MenuDto> restructuredList = new ArrayList<>();
+        for (String menuName : data){
+            restructuredList.add(findByName(menuName));
+        }
+        return restructuredList;
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
resolve #10

## 📝 개요
재구성된 메뉴 리스트 조회 API 구현

## ✨ 작업 사항
- FE에서 이미지 받아오기
- ML에 이미지 보내주기
- ML에서 텍스트 리스트 받아 메뉴 검색하고 FE에 재구성한 메뉴 리스트 보내주는 로직 구현
  ### 메뉴 검색해오는 테스트하면서 추가한 내용
  - Wikipedia API에서 받아오는 뜻 255자 이상일 경우, 길이 제한
  - 뜻이 아니라 '영양성분' 정보일 경우, 빈 스트링으로 처리

## 📚 참고 사항
<!-- 공유할 내용, 레퍼런스, 추가로 발생할 것으로 예상되는 이슈가 있다면 적어주세요-->
- 클라우드 환경에서 테스트 필요함
  - 테스트 할 때, MlClient 클래스에서 아래 코드 부분 ML 서버 주소로 수정 필요

    ```java
    WebClient client = WebClient.create("http://localhost:8080");
    ```
  - 테스트 끝나면, ML 서버 역할을 하기 위해 만들어뒀던 코드들 삭제하기
- [MultipartFile 전송 시 오류 해결 레퍼런스](https://lovia98.github.io/blog/file-http-convert/) 