### PR TITLE
Feature/#15-text-filtering

### DIFF
--- a/src/main/java/com/podong/icanread/app/dto/MenuDto.java
+++ b/src/main/java/com/podong/icanread/app/dto/MenuDto.java
@@ -16,4 +16,10 @@ public class MenuDto {
         this.meaning = entity.getMeaning();
         this.image = entity.getImage();
     }
+
+    public MenuDto(String name, String meaning, String image) {
+        this.name = name;
+        this.meaning = meaning;
+        this.image = image;
+    }
 }

--- a/src/main/java/com/podong/icanread/app/ml/MlClient.java
+++ b/src/main/java/com/podong/icanread/app/ml/MlClient.java
@@ -57,6 +57,7 @@ public class MlClient {
         textList.add("카페모카");
         textList.add("화이트 카페모카");
         textList.add("카라멜 마키아또");
+        textList.add("카라멜 마끼아또");
         textList.add("콜드브루");
         textList.add("아인슈페너");
         textList.add("아포가토");
@@ -68,7 +69,7 @@ public class MlClient {
         textList.add("초코 라떼");
         textList.add("헤이즐넛 라떼");
         textList.add("콜드브루 라떼");
-        textList.add("그린티");
+        textList.add("녹차");
         textList.add("아이스티");
         textList.add("얼그레이");
         textList.add("캐모마일");
@@ -94,6 +95,8 @@ public class MlClient {
         textList.add("키위 주스");
         textList.add("오렌지 주스");
         textList.add("토마토 주스");
+        textList.add("홍차");
+        textList.add("플레인 요거트 스무디");
         MlResponseDto mlResponseDto = new MlResponseDto();
         mlResponseDto.setTextList(textList);
         return mlResponseDto;

--- a/src/main/java/com/podong/icanread/domain/menu/Menu.java
+++ b/src/main/java/com/podong/icanread/domain/menu/Menu.java
@@ -27,7 +27,7 @@ public class Menu {
     private String meaning;
 
     // 테이블 칼럼 - 메뉴 이미지 URL
-    @Column(nullable = false)
+    @Column(nullable = false, length = 500)
     private String image;
 
     @Builder

--- a/src/test/java/com/podong/icanread/service/menu/MenuServiceTest.java
+++ b/src/test/java/com/podong/icanread/service/menu/MenuServiceTest.java
@@ -1,5 +1,7 @@
 package com.podong.icanread.service.menu;
 
+import com.podong.icanread.app.dto.MenuDto;
+import com.podong.icanread.app.ml.MlClient;
 import com.podong.icanread.app.wikipedia.WikipediaClient;
 import com.podong.icanread.domain.menu.Menu;
 import com.podong.icanread.domain.menu.MenuRepository;
@@ -13,7 +15,11 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Optional;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -32,7 +38,7 @@ public class MenuServiceTest {
 
     @BeforeEach
     void setup() {
-        this.menuService = new MenuService(menuRepository);
+        this.menuService = new MenuService(menuRepository, new MlClient());
     }
 
     @AfterEach
@@ -63,5 +69,50 @@ public class MenuServiceTest {
         wikipediaClient = new WikipediaClient("카페라떼");
         System.out.println(wikipediaClient.getMeaning());
         System.out.println(wikipediaClient.getImageURL());
+    }
+
+    @Test
+    @DisplayName("Text List 받아서 하나씩 검색해오는지 확인")
+    public void changeTextList_toMenuList() throws ParseException {
+        String[] data = {"에스프레소", "아메리카노", "카페 모카", "카페 라떼", "카푸치노", "캐러멜 마키아토", "민트 초콜릿",
+                "에스프레소", "바닐라 라떼", "차가운 음료", "오렌지 주스", "애플 주스", "아이스 라떼", "아이스 모카", "아이스 티",
+                "디저트", "레드 벨벳 케이크", "마카롱", "크루아상", "치즈 케이크", "애플 파이", "피칸 파이", "초콜릿 케이크",
+                "민트 컵케이크", "샌드위치", "달걀 & 햄", "오몰렛", "햄 & 치즈", "햄버거", "치즈 버거"};
+        ArrayList<String> restructuredList = new ArrayList<>(Arrays.asList(data));
+        for (String s : restructuredList) {
+            System.out.println(s);
+        }
+    }
+
+    @Test
+    @DisplayName("ML에서 받아온 텍스트 메뉴인지 검증")
+    public void excludeMenu_onlyNumber() {
+        String[] data = {"에스프레소", "아메리카노", "빵", "10000", "10,000", "2", "10.0", "2,400", "24,0", "에24", "카페 모카", "바닐라 라떼", "레드 벨벳 케이크", "100", "홍차", "녹차"};
+        final String menuPrice = "[0-9]+[.,]?[0-9]+";
+        for (String menuName : data){
+            String menuNameWithSpacesRemoved = menuName.replaceAll("\\s", ""); // 공백 제거
+            boolean isTea = menuName.equals("홍차") || menuName.equals("녹차");
+            boolean isShortOrPrice = menuNameWithSpacesRemoved.length() < 3 || menuNameWithSpacesRemoved.matches(menuPrice);
+            if (isTea || !isShortOrPrice){ // 3글자 미만 텍스트 또는 가격일 경우 제외 (홍차, 녹차는 예외적으로 포함)
+                System.out.println(menuName);
+            }
+        }
+    }
+
+    @Test
+    @DisplayName("스무디가 포함된 경우 스무디 뜻 가져와서 스무디 앞 단어 포함해 재구성하기")
+    public void reconstructMeaning() {
+        String smoothieMeaning = "name는 ingredient와(과) 우유, 요거트 등을 섞어 만든 달콤한 음료이다.";
+        String name = "사과 스무디";
+        Matcher matcher = Pattern.compile("스무디").matcher(name);
+        String ingredient = "";
+        while(matcher.find()) {
+            ingredient = name.substring(0, matcher.start()); // 스무디의 재료
+            ingredient = ingredient.replaceAll("\\s", ""); // 공백 제거
+            System.out.println(ingredient);
+        }
+        String nameReplace = smoothieMeaning.replaceAll("name", name);
+        String ingredientReplace = nameReplace.replaceAll("ingredient", ingredient);
+        System.out.println(ingredientReplace);
     }
 }


### PR DESCRIPTION
## 📌 관련 이슈
resolve #15

## 📝 개요
ML에서 받아오는 텍스트들 필터링 작업

## ✨ 작업 사항
#### ML에서 받아오는 텍스트들 검증하기 위한 조건 추가
- 가격이 아니어야 함
- 3글자 이상의 텍스트여야 함 (단, 예외적으로 홍차, 녹차는 포함)

#### 메뉴명 공백 관련 로직 추가
- DB에 저장할 때는 공백 제거
- DB에 검색할 때는 공백 제거
- 위키피디아 API, 네이버 사전 API에 검색할 때는 공백 포함
- FE에게 보내줄 때는 공백 포함

## 📚 참고 사항
meaning 자체 재구성은 일단 테스트 코드로 짜놓기만 함. 너무 경우의 수가 많은 것 같아서 아직 적용하지는 않음. 